### PR TITLE
Fixed bug with Field initialization using South

### DIFF
--- a/audit_log/models/fields.py
+++ b/audit_log/models/fields.py
@@ -8,7 +8,7 @@ class LastUserField(models.ForeignKey):
     of a model. None will be the value for AnonymousUser.
     """
     
-    def __init__(self, null = True, **kwargs):
+    def __init__(self, to=User, null = True, **kwargs):
         super(LastUserField, self).__init__(User, null = True, **kwargs)
     
     def contribute_to_class(self, cls, name):


### PR DESCRIPTION
South provides all arguments like: to, null. Thus, we have an error because of duplicating of same arguments
