### PR TITLE
Added 'app_label' to related_name to avoid clashes

### DIFF
--- a/audit_log/models/__init__.py
+++ b/audit_log/models/__init__.py
@@ -7,9 +7,9 @@ class AuthStampedModel(Model):
 	An abstract base class model that provides auth and session information
 	fields.
 	"""
-	created_by = CreatingUserField(verbose_name = _("created by"), related_name = "created_%(class)s_set")
+	created_by = CreatingUserField(verbose_name = _("created by"), related_name = "created_%(app_label)s_%(class)s_set")
 	created_with_session_key = CreatingSessionKeyField(_("created with session key"))
-	modified_by =  LastUserField(verbose_name = _("modified by"), related_name = "modified_%(class)s_set")
+	modified_by =  LastUserField(verbose_name = _("modified by"), related_name = "modified_%(app_label)s_%(class)s_set")
 	modified_with_session_key = LastSessionKeyField(_("modified with session key"))
 
 	class Meta:


### PR DESCRIPTION
Its possible for two different apps to have models that have the same name. The current related name structure assumes that all models in the entire project have a unique name. 
