### PR TITLE
Prevented creation of permissions by default for audit log models.

### DIFF
--- a/audit_log/models/managers.py
+++ b/audit_log/models/managers.py
@@ -183,6 +183,7 @@ class AuditLog(object):
         return {
             'ordering' : ('-action_date',),
             'app_label' : model._meta.app_label,
+            'default_permissions': (),
         }
     
     def create_log_entry_model(self, model):


### PR DESCRIPTION
As audit log verbose names are long and can't be easily changed, they quickly run into the maximum permission name length. In addition, I don't think it makes sense to create audit log model permissions by default in any case. This patch disables creation.
