### PR TITLE
Fix for audit_log ForeignKey on custom AUTH_USER_MODEL.

### DIFF
--- a/audit_log/models/fields.py
+++ b/audit_log/models/fields.py
@@ -9,10 +9,17 @@ class LastUserField(models.ForeignKey):
     A field that keeps the last user that saved an instance
     of a model. None will be the value for AnonymousUser.
     """
-    
-    def __init__(self, to = getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), null = True, editable = False,  **kwargs):
+
+    def __init__(self, to=None, null=True, editable=False, **kwargs):
+        if to is None:
+            to = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+            # make sure to='self' when relating to AUTH_USER_MODEL.
+            if kwargs['related_name'] == '_%s_audit_log_entry' % (
+                to.split('.')[1].lower(),
+            ):
+                to = 'self'
         super(LastUserField, self).__init__(to = to, null = null, editable = editable, **kwargs)
-    
+
     def contribute_to_class(self, cls, name):
         super(LastUserField, self).contribute_to_class(cls, name)
         registry = registration.FieldRegistry(self.__class__)
@@ -22,10 +29,10 @@ class LastSessionKeyField(models.CharField):
     """
     A field that keeps a reference to the last session key that was used to access the model.
     """
-    
+
     def __init__(self, max_length  = 40, null = True, editable = False,  **kwargs):
         super(LastSessionKeyField, self).__init__(max_length = 40, null = null, editable = editable, **kwargs)
-    
+
     def contribute_to_class(self, cls, name):
         super(LastSessionKeyField, self).contribute_to_class(cls, name)
         registry = registration.FieldRegistry(self.__class__)
@@ -53,8 +60,8 @@ class CreatingSessionKeyField(LastSessionKeyField):
 #South stuff:
 
 rules = [((LastUserField, CreatingUserField),
-    [],    
-    {   
+    [],
+    {
         'to': ['rel.to', {'default': getattr(settings, 'AUTH_USER_MODEL', 'auth.User')}],
         'null': ['null', {'default': True}],
     },)]


### PR DESCRIPTION
We were getting an error when using "audit_log = AuditLog()" on a custom user model (inheriting from django.contrib.auth.mdoels.AbstractBaseUser):

```
$ manage.py validate
CommandError: System check identified some issues:

ERRORS:
karaage.PersonAuditLogEntry.action_user: (fields.E300) Field defines a relation with model 'karaage.Person', which is either not installed, or is abstract.

System check identified 1 issue (2 silenced).
```

The quick and dirty fix was to compare the kwargs['related_name'] with the relation target (to) and use "self" instead.  We're open to alternate fixes...
