### PR TITLE
Allow global disabling

### DIFF
--- a/audit_log/__init__.py
+++ b/audit_log/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 0, 'final')
+VERSION = (0, 7, 0, 1, 'final')
 
 if VERSION[-1] != "final": # pragma: no cover
     __version__ = '.'.join(map(str, VERSION))

--- a/audit_log/__init__.py
+++ b/audit_log/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 0, 1, 'final')
+VERSION = (0, 7, 0, 'final')
 
 if VERSION[-1] != "final": # pragma: no cover
     __version__ = '.'.join(map(str, VERSION))

--- a/audit_log/middleware.py
+++ b/audit_log/middleware.py
@@ -1,7 +1,7 @@
 from django.db.models import signals
 from django.utils.functional import curry
 
-from audit_log import registration
+from audit_log import registration, settings
 from audit_log.models import fields
 from audit_log.models.managers import AuditLogManager
 
@@ -24,6 +24,8 @@ def _enable_audit_log_managers(instance):
 
 class UserLoggingMiddleware(object):
     def process_request(self, request):
+        if settings.DISABLE_AUDIT_LOG:
+            return
         if not request.method in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
             if hasattr(request, 'user') and request.user.is_authenticated():
                 user = request.user
@@ -39,6 +41,8 @@ class UserLoggingMiddleware(object):
             signals.post_save.connect(update_post_save_info,  dispatch_uid = (self.__class__, request,), weak = False)
 
     def process_response(self, request, response):
+        if settings.DISABLE_AUDIT_LOG:
+            return
         signals.pre_save.disconnect(dispatch_uid =  (self.__class__, request,))
         signals.post_save.disconnect(dispatch_uid =  (self.__class__, request,))
         return response

--- a/audit_log/models/managers.py
+++ b/audit_log/models/managers.py
@@ -8,6 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
 from audit_log.models.fields import LastUserField
+from audit_log import settings
 
 
 try:
@@ -55,6 +56,8 @@ class AuditLogManager(models.Manager):
         setattr(self.instance, '__is_%s_enabled'%self.attname, False)
 
     def is_tracking_enabled(self):
+        if settings.DISABLE_AUDIT_LOG:
+            return False
         if self.instance is None:
             raise ValueError("Tracking can only be enabled or disabled "
                                     "per model instance, not on a model class")

--- a/audit_log/settings.py
+++ b/audit_log/settings.py
@@ -1,0 +1,3 @@
+from django.conf import settings as global_settings
+
+DISABLE_AUDIT_LOG = getattr(global_settings, 'DISABLE_AUDIT_LOG', False)


### PR DESCRIPTION
Adding a setting which allows for global disabling of audit log. Useful for speeding up testing, and I'm sure elsewhere