### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,15 +5,15 @@
 .. image:: https://badges.gitter.im/Join Chat.svg
    :target: https://gitter.im/Atomidata/django-audit-log?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
-.. image:: https://pypip.in/version/django-audit-log/badge.svg
+.. image:: https://img.shields.io/pypi/v/django-audit-log.svg
     :target: https://pypi.python.org/pypi/django-audit-log/
     :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/django-audit-log/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/django-audit-log.svg
     :target: https://pypi.python.org/pypi/django-audit-log/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/format/django-audit-log/badge.svg
+.. image:: https://img.shields.io/pypi/format/django-audit-log.svg
     :target: https://pypi.python.org/pypi/django-audit-log/
     :alt: Download format
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-audit-log))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-audit-log`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.