### PR TITLE
Do not overwrite creating fields if were set explicitly

### DIFF
--- a/audit_log/__init__.py
+++ b/audit_log/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 9, 0, 'alpha')
+VERSION = (0, 9, 1, 'alpha')
 
 if VERSION[-1] != "final": # pragma: no cover
     __version__ = '.'.join(map(str, VERSION))

--- a/audit_log/__init__.py
+++ b/audit_log/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 8, 0, 'final')
+VERSION = (0, 9, 0, 'alpha')
 
 if VERSION[-1] != "final": # pragma: no cover
     __version__ = '.'.join(map(str, VERSION))

--- a/audit_log/middleware.py
+++ b/audit_log/middleware.py
@@ -57,12 +57,14 @@ class UserLoggingMiddleware(MiddlewareMixin):
         registry = registration.FieldRegistry(fields.LastUserField)
         if sender in registry:
             for field in registry.get_fields(sender):
-                setattr(instance, field.name, user)
+                if not getattr(instance, field.name, None):
+                    setattr(instance, field.name, user)
 
         registry = registration.FieldRegistry(fields.LastSessionKeyField)
         if sender in registry:
             for field in registry.get_fields(sender):
-                setattr(instance, field.name, session)
+                if not getattr(instance, field.name, None):
+                    setattr(instance, field.name, session)
 
 
     def _update_post_save_info(self, user, session, sender, instance, created, **kwargs ):

--- a/audit_log/middleware.py
+++ b/audit_log/middleware.py
@@ -57,13 +57,13 @@ class UserLoggingMiddleware(MiddlewareMixin):
         registry = registration.FieldRegistry(fields.LastUserField)
         if sender in registry:
             for field in registry.get_fields(sender):
-                if not getattr(instance, field.name, None):
+                if user:
                     setattr(instance, field.name, user)
 
         registry = registration.FieldRegistry(fields.LastSessionKeyField)
         if sender in registry:
             for field in registry.get_fields(sender):
-                if not getattr(instance, field.name, None):
+                if user:
                     setattr(instance, field.name, session)
 
 

--- a/audit_log/middleware.py
+++ b/audit_log/middleware.py
@@ -70,19 +70,21 @@ class UserLoggingMiddleware(MiddlewareMixin):
             registry = registration.FieldRegistry(fields.CreatingUserField)
             if sender in registry:
                 for field in registry.get_fields(sender):
-                    setattr(instance, field.name, user)
-                    _disable_audit_log_managers(instance)
-                    instance.save()
-                    _enable_audit_log_managers(instance)
+                    if not getattr(instance, field.name, None):
+                        setattr(instance, field.name, user)
+                        _disable_audit_log_managers(instance)
+                        instance.save()
+                        _enable_audit_log_managers(instance)
 
 
             registry = registration.FieldRegistry(fields.CreatingSessionKeyField)
             if sender in registry:
                 for field in registry.get_fields(sender):
-                    setattr(instance, field.name, session)
-                    _disable_audit_log_managers(instance)
-                    instance.save()
-                    _enable_audit_log_managers(instance)
+                    if not getattr(instance, field.name, None):
+                        setattr(instance, field.name, session)
+                        _disable_audit_log_managers(instance)
+                        instance.save()
+                        _enable_audit_log_managers(instance)
 
 
 

--- a/audit_log/middleware.py
+++ b/audit_log/middleware.py
@@ -57,14 +57,12 @@ class UserLoggingMiddleware(MiddlewareMixin):
         registry = registration.FieldRegistry(fields.LastUserField)
         if sender in registry:
             for field in registry.get_fields(sender):
-                if user:
-                    setattr(instance, field.name, user)
+                setattr(instance, field.name, user)
 
         registry = registration.FieldRegistry(fields.LastSessionKeyField)
         if sender in registry:
             for field in registry.get_fields(sender):
-                if user:
-                    setattr(instance, field.name, session)
+                setattr(instance, field.name, session)
 
 
     def _update_post_save_info(self, user, session, sender, instance, created, **kwargs ):


### PR DESCRIPTION
Sometimes, I'd like to specify different user for `CreatingUserField` field by myself. Such cases are rare, usually I'm ok with populating this field from `request.user` automatically. But they still happens.

Example:

```python
from audit_log.models.fields import CreatingUserField

class MyModel(models.Model):

    created_by = CreatingUserField(...)

# --------------------

def my_view(request):

    if request.method == 'POST':
        # created_by will be filled from request.user, that is ok
        MyModel.objects.create()
        
        # but here I'd like to change the created_by user.
        # I can't do this because it will be always
        # equal to request.user. Since I've specified the user explicitly - audit_log
        # should assume that I know what I'm doing.
        another_user = User.objects.get(id=123)
        MyModel.objects.create(created_by=another_user)
```

Solution: fill `CreatingUserField` automatically only if no value was provided. Otherwise - don't overwrite it.

This PR miss the tests. I'll add them if such behaviour will be approved. 